### PR TITLE
[KODO-6743] support shardingStatistics

### DIFF
--- a/collector/mongod/server_status.go
+++ b/collector/mongod/server_status.go
@@ -83,6 +83,8 @@ type ServerStatus struct {
 
 	Cursors *Cursors `bson:"cursors"`
 
+	ShardingStatistics *ShardingStatistics `bson:"shardingStatistics"`
+
 	StorageEngine *StorageEngineStats `bson:"storageEngine"`
 	InMemory      *WiredTigerStats    `bson:"inMemory"`
 	RocksDb       *RocksDbStats       `bson:"rocksdb"`
@@ -144,6 +146,9 @@ func (status *ServerStatus) Export(ch chan<- prometheus.Metric) {
 	}
 	if status.Cursors != nil {
 		status.Cursors.Export(ch)
+	}
+	if status.ShardingStatistics != nil {
+		status.ShardingStatistics.Export(ch)
 	}
 	if status.InMemory != nil {
 		status.InMemory.Export(ch)
@@ -218,6 +223,9 @@ func (status *ServerStatus) Describe(ch chan<- *prometheus.Desc) {
 	}
 	if status.Cursors != nil {
 		status.Cursors.Describe(ch)
+	}
+	if status.ShardingStatistics != nil {
+		status.ShardingStatistics.Describe(ch)
 	}
 	if status.StorageEngine != nil {
 		status.StorageEngine.Describe(ch)

--- a/collector/mongod/shardingStatistics.go
+++ b/collector/mongod/shardingStatistics.go
@@ -69,6 +69,11 @@ var (
 		Name:      shardingStatCatalogCachePrefix + "num_active_full_refreshes",
 		Help:      "The number of full catalog cache refreshes that are currently waiting to complete.",
 	}, []string{})
+	countFullRefreshesStarted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "count_full_refreshes_started",
+		Help:      "The cumulative number of full refreshes that have started",
+	}, []string{})
 	countFailedRefreshes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      shardingStatCatalogCachePrefix + "count_failed_refreshes",
@@ -116,6 +121,7 @@ func (c *catalogCache) update() {
 	numActiveIncrementalRefreshes.WithLabelValues().Set(c.NumActiveIncrementalRefreshes)
 	countIncrementalRefreshesStarted.WithLabelValues().Set(c.CountIncrementalRefreshesStarted)
 	numActiveFullRefreshes.WithLabelValues().Set(c.NumActiveFullRefreshes)
+	countFullRefreshesStarted.WithLabelValues().Set(c.CountFullRefreshesStarted)
 	countFailedRefreshes.WithLabelValues().Set(c.CountFailedRefreshes)
 }
 
@@ -140,6 +146,7 @@ func (c *catalogCache) Export(ch chan<- prometheus.Metric) {
 	numActiveIncrementalRefreshes.Collect(ch)
 	countIncrementalRefreshesStarted.Collect(ch)
 	numActiveFullRefreshes.Collect(ch)
+	countFullRefreshesStarted.Collect(ch)
 	countFailedRefreshes.Collect(ch)
 }
 

--- a/collector/mongod/shardingStatistics.go
+++ b/collector/mongod/shardingStatistics.go
@@ -1,0 +1,167 @@
+package mongod
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const shardingStatPrefix = "sharding_stat_"
+const shardingStatCatalogCachePrefix = shardingStatPrefix + "catalog_cache_"
+
+var (
+	countStaleConfigErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatPrefix + "stale_config_errors_total",
+		Help:      "The total number of times that threads hit stale config exception",
+	}, []string{})
+
+	countDonorMoveChunkStarted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatPrefix + "donor_move_chunk_start_total",
+		Help:      "The total number of times that the moveChunk command has started on the shard",
+	}, []string{})
+	totalDonorChunkCloneTimeMillis = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatPrefix + "donor_chunk_clone_time_ms_total",
+		Help:      "The cumulative time, in milliseconds, taken by the clone phase of the chunk migrations from this shard, of which this node is a member.",
+	}, []string{})
+	totalCriticalSectionCommitTimeMillis = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatPrefix + "critical_section_commit_time_ms_total",
+		Help:      "The cumulative time, in milliseconds, taken by the update metadata phase of the chunk migrations from this shard, of which this node is a member.",
+	}, []string{})
+	totalCriticalSectionTimeMillis = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatPrefix + "critical_section_time_ms_total",
+		Help:      "The cumulative time, in milliseconds, taken by the catch-up phase and the update metadata phase of the chunk migrations from this shard, of which this node is a member.",
+	}, []string{})
+	numDatabaseEntries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "num_database_entries",
+		Help:      "The total number of database entries that are currently in the catalog cache.",
+	}, []string{})
+	numCollectionEntries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "num_collection_entries",
+		Help:      "The total number of database entries that are currently in the catalog cache.",
+	}, []string{})
+	catalogCacheCountStaleConfigErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "count_stale_config_errors",
+		Help:      "The total number of database entries that are currently in the catalog cache.",
+	}, []string{})
+	totalRefreshWaitTimeMicros = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "total_refresh_wait_time_micros",
+		Help:      "The cumulative time, in microseconds, that threads had to wait for a refresh of the metadata.",
+	}, []string{})
+	numActiveIncrementalRefreshes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "num_active_incremental_refreshes",
+		Help:      "The number of incremental catalog cache refreshes that are currently waiting to complete.",
+	}, []string{})
+	countIncrementalRefreshesStarted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "count_incremental_refreshes_started",
+		Help:      "The cumulative number of incremental refreshes that have started.",
+	}, []string{})
+	numActiveFullRefreshes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "num_active_full_refreshes",
+		Help:      "The number of full catalog cache refreshes that are currently waiting to complete.",
+	}, []string{})
+	countFailedRefreshes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      shardingStatCatalogCachePrefix + "count_failed_refreshes",
+		Help:      "The cumulative number of full or incremental refreshes that have failed.",
+	}, []string{})
+)
+
+// ShardingStatistics https://docs.mongodb.com/manual/reference/command/serverStatus/#shardingstatistics
+type ShardingStatistics struct {
+	CountStaleConfigErrors               float64      `bson:"countStaleConfigErrors"`
+	CountDonorMoveChunkStarted           float64      `bson:"countDonorMoveChunkStarted"`
+	TotalDonorChunkCloneTimeMillis       float64      `bson:"totalDonorChunkCloneTimeMillis"`
+	TotalCriticalSectionCommitTimeMillis float64      `bson:"totalCriticalSectionCommitTimeMillis"`
+	TotalCriticalSectionTimeMillis       float64      `bson:"totalCriticalSectionTimeMillis"`
+	CatalogCache                         catalogCache `bson:"catalogCache"`
+}
+
+type catalogCache struct {
+	NumDatabaseEntries               float64 `bson:"numDatabaseEntries"`
+	NumCollectionEntries             float64 `bson:"numCollectionEntries"`
+	CountStaleConfigErrors           float64 `bson:"countStaleConfigErrors"`
+	TotalRefreshWaitTimeMicros       float64 `bson:"totalRefreshWaitTimeMicros"`
+	NumActiveIncrementalRefreshes    float64 `bson:"numActiveIncrementalRefreshes"`
+	CountIncrementalRefreshesStarted float64 `bson:"countIncrementalRefreshesStarted"`
+	NumActiveFullRefreshes           float64 `bson:"numActiveFullRefreshes"`
+	CountFullRefreshesStarted        float64 `bson:"countFullRefreshesStarted"`
+	CountFailedRefreshes             float64 `bson:"countFailedRefreshes"`
+}
+
+func (s *ShardingStatistics) update() {
+	countStaleConfigErrors.WithLabelValues().Set(s.CountStaleConfigErrors)
+	countDonorMoveChunkStarted.WithLabelValues().Set(s.CountDonorMoveChunkStarted)
+	totalDonorChunkCloneTimeMillis.WithLabelValues().Set(s.TotalDonorChunkCloneTimeMillis)
+	totalCriticalSectionCommitTimeMillis.WithLabelValues().Set(s.TotalCriticalSectionCommitTimeMillis)
+	totalCriticalSectionTimeMillis.WithLabelValues().Set(s.TotalCriticalSectionTimeMillis)
+
+	s.CatalogCache.update()
+}
+
+func (c *catalogCache) update() {
+	numDatabaseEntries.WithLabelValues().Set(c.NumDatabaseEntries)
+	numCollectionEntries.WithLabelValues().Set(c.NumCollectionEntries)
+	catalogCacheCountStaleConfigErrors.WithLabelValues().Set(c.CountStaleConfigErrors)
+	totalRefreshWaitTimeMicros.WithLabelValues().Set(c.TotalRefreshWaitTimeMicros)
+	numActiveIncrementalRefreshes.WithLabelValues().Set(c.NumActiveIncrementalRefreshes)
+	countIncrementalRefreshesStarted.WithLabelValues().Set(c.CountIncrementalRefreshesStarted)
+	numActiveFullRefreshes.WithLabelValues().Set(c.NumActiveFullRefreshes)
+	countFailedRefreshes.WithLabelValues().Set(c.CountFailedRefreshes)
+}
+
+// Export exports the data to prometheus.
+func (s *ShardingStatistics) Export(ch chan<- prometheus.Metric) {
+	s.update()
+	countStaleConfigErrors.Collect(ch)
+	countDonorMoveChunkStarted.Collect(ch)
+	totalDonorChunkCloneTimeMillis.Collect(ch)
+	totalCriticalSectionCommitTimeMillis.Collect(ch)
+	totalCriticalSectionTimeMillis.Collect(ch)
+
+	s.CatalogCache.Export(ch)
+}
+
+// Export exports the data to prometheus.
+func (c *catalogCache) Export(ch chan<- prometheus.Metric) {
+	numDatabaseEntries.Collect(ch)
+	numCollectionEntries.Collect(ch)
+	catalogCacheCountStaleConfigErrors.Collect(ch)
+	totalRefreshWaitTimeMicros.Collect(ch)
+	numActiveIncrementalRefreshes.Collect(ch)
+	countIncrementalRefreshesStarted.Collect(ch)
+	numActiveFullRefreshes.Collect(ch)
+	countFailedRefreshes.Collect(ch)
+}
+
+// Describe describes the metrics for prometheus
+func (s *ShardingStatistics) Describe(ch chan<- *prometheus.Desc) {
+	countStaleConfigErrors.Describe(ch)
+	countDonorMoveChunkStarted.Describe(ch)
+	totalDonorChunkCloneTimeMillis.Describe(ch)
+	totalCriticalSectionCommitTimeMillis.Describe(ch)
+	totalCriticalSectionTimeMillis.Describe(ch)
+
+	s.CatalogCache.Describe(ch)
+}
+
+// Describe describes the metrics for prometheus
+func (c *catalogCache) Describe(ch chan<- *prometheus.Desc) {
+	numDatabaseEntries.Describe(ch)
+	numCollectionEntries.Describe(ch)
+	catalogCacheCountStaleConfigErrors.Describe(ch)
+	totalRefreshWaitTimeMicros.Describe(ch)
+	numActiveIncrementalRefreshes.Describe(ch)
+	countIncrementalRefreshesStarted.Describe(ch)
+	numActiveFullRefreshes.Describe(ch)
+	countFailedRefreshes.Describe(ch)
+}

--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -28,7 +28,13 @@ import (
 	"github.com/percona/mongodb_exporter/shared"
 )
 
-const namespace = "mongodb"
+const (
+	namespace     = "mongodb"
+	nodeMongos    = "mongos"
+	nodeMongod    = "mongod"
+	nodeReplset   = "replset"
+	nodeConfigSvr = "configsvr"
+)
 
 // MongodbCollectorOpts is the options of the mongodb collector.
 type MongodbCollectorOpts struct {
@@ -45,19 +51,23 @@ type MongodbCollectorOpts struct {
 	CollectIndexUsageStats   bool
 	SocketTimeout            time.Duration
 	SyncTimeout              time.Duration
+	EnableMongosShardingStat       bool
+	EnableConfigSvrShardingStat    bool
 }
 
 func (in *MongodbCollectorOpts) toSessionOps() *shared.MongoSessionOpts {
 	return &shared.MongoSessionOpts{
-		URI:                   in.URI,
-		TLSConnection:         in.TLSConnection,
-		TLSCertificateFile:    in.TLSCertificateFile,
-		TLSPrivateKeyFile:     in.TLSPrivateKeyFile,
-		TLSCaFile:             in.TLSCaFile,
-		TLSHostnameValidation: in.TLSHostnameValidation,
-		PoolLimit:             in.DBPoolLimit,
-		SocketTimeout:         in.SocketTimeout,
-		SyncTimeout:           in.SyncTimeout,
+		URI:                         in.URI,
+		TLSConnection:               in.TLSConnection,
+		TLSCertificateFile:          in.TLSCertificateFile,
+		TLSPrivateKeyFile:           in.TLSPrivateKeyFile,
+		TLSCaFile:                   in.TLSCaFile,
+		TLSHostnameValidation:       in.TLSHostnameValidation,
+		PoolLimit:                   in.DBPoolLimit,
+		SocketTimeout:               in.SocketTimeout,
+		SyncTimeout:                 in.SyncTimeout,
+		EnableMongosShardingStat:    in.EnableMongosShardingStat,
+		EnableConfigSvrShardingStat: in.EnableConfigSvrShardingStat,
 	}
 }
 
@@ -221,12 +231,14 @@ func (exporter *MongodbCollector) scrape(ch chan<- prometheus.Metric) {
 
 	log.Debugf("Connected to: %s (node type: %s, server version: %s)", shared.RedactMongoUri(exporter.Opts.URI), nodeType, serverVersion)
 	switch {
-	case nodeType == "mongos":
+	case nodeType == nodeMongos:
 		exporter.collectMongos(mongoSess, ch)
-	case nodeType == "mongod":
+	case nodeType == nodeMongod:
 		exporter.collectMongod(mongoSess, ch)
-	case nodeType == "replset":
+	case nodeType == nodeReplset:
 		exporter.collectMongodReplSet(mongoSess, ch)
+	case nodeType == nodeConfigSvr:
+		exporter.collectConfigSvr(mongoSess, ch)
 	default:
 		err = fmt.Errorf("Unrecognized node type %s", nodeType)
 		log.Error(err)
@@ -243,10 +255,12 @@ func (exporter *MongodbCollector) collectMongos(session *mgo.Session, ch chan<- 
 		serverStatus.Export(ch)
 	}
 
-	log.Debug("Collecting Sharding Status")
-	shardingStatus := mongos.GetShardingStatus(session)
-	if shardingStatus != nil {
-		shardingStatus.Export(ch)
+	if exporter.Opts.EnableMongosShardingStat {
+		log.Info("Collecting Sharding Status")
+		shardingStatus := mongos.GetShardingStatus(session)
+		if shardingStatus != nil {
+			shardingStatus.Export(ch)
+		}
 	}
 
 	if exporter.Opts.CollectDatabaseMetrics {
@@ -262,6 +276,18 @@ func (exporter *MongodbCollector) collectMongos(session *mgo.Session, ch chan<- 
 		collStatList := mongos.GetCollectionStatList(session)
 		if collStatList != nil {
 			collStatList.Export(ch)
+		}
+	}
+}
+
+func (exporter *MongodbCollector) collectConfigSvr(session *mgo.Session, ch chan<- prometheus.Metric) {
+	exporter.collectMongodReplSet(session, ch)
+
+	if exporter.Opts.EnableConfigSvrShardingStat {
+		log.Info("Collecting Sharding Status")
+		shardingStatus := mongos.GetShardingStatus(session)
+		if shardingStatus != nil {
+			shardingStatus.Export(ch)
 		}
 	}
 }

--- a/collector/mongos/sharding_topology.go
+++ b/collector/mongos/sharding_topology.go
@@ -186,12 +186,12 @@ func (status *ShardingTopoStats) Describe(ch chan<- *prometheus.Desc) {
 	shardingTopoInfoTotalCollections.Describe(ch)
 }
 
-func GetShardingTopoStatus(session *mgo.Session) *ShardingTopoStats {
+func GetShardingTopoStatus(session *mgo.Session, shardChunkInfoAll *[]ShardingTopoChunkInfo) *ShardingTopoStats {
 	results := &ShardingTopoStats{}
 
 	results.Shards = GetShards(session)
 	results.TotalChunks = GetTotalChunks(session)
-	results.ShardChunks = GetTotalChunksByShard(session)
+	results.ShardChunks = shardChunkInfoAll
 	results.TotalDatabases = GetTotalDatabases(session)
 	results.TotalCollections = GetTotalShardedCollections(session)
 

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -73,6 +73,8 @@ var (
 	// FIXME currently ignored
 	// enabledGroupsFlag = flag.String("groups.enabled", "asserts,durability,background_flushing,connections,extra_info,global_lock,index_counters,network,op_counters,op_counters_repl,memory,locks,metrics", "Comma-separated list of groups to use, for more info see: docs.mongodb.org/manual/reference/command/serverStatus/")
 	enabledGroupsFlag = flag.String("groups.enabled", "", "Currently ignored")
+	enabledMongosShardingStat  = flag.Bool("mongos.sharding-stat", false, "whether collect sharding stats from mongos")
+	enabledConfigSvrShardingStat  = flag.Bool("configsvr.sharding-stat", false, "whether collect sharding stats from config svr")
 )
 
 func main() {
@@ -126,6 +128,8 @@ func main() {
 		CollectIndexUsageStats:   *collectIndexUsageF,
 		SocketTimeout:            *socketTimeoutF,
 		SyncTimeout:              *syncTimeoutF,
+		EnableMongosShardingStat: *enabledMongosShardingStat,
+		EnableConfigSvrShardingStat:*enabledConfigSvrShardingStat,
 	})
 	prometheus.MustRegister(mongodbCollector)
 


### PR DESCRIPTION
https://jira.qiniu.io/browse/KODO-6743

change set:
1. 添加mongos.sharding-stat和configsvr.sharding-stat选项，选择是否在mongos或configsvr的从节点收集sharding统计信息（已上线）
2. 优化GetShardingStatus()方法，减少GetTotalChunksByShard查询次数（已上线）
3. 添加[serverstatus.shardingStatistics](https://docs.mongodb.com/manual/reference/command/serverStatus/#serverstatus.shardingStatistics)信息导出